### PR TITLE
Fix several compile errors on Clozure Common Lisp 1.6.

### DIFF
--- a/defpackage.lisp
+++ b/defpackage.lisp
@@ -18,7 +18,7 @@
    #:resolvable #:backlinkable #:root #:titular #:predecorative
    #:prebibliographic #:bibliographic #:decorative #:body #:general
    #:sequential #:abmonition #:special #:invisible #:part
-   #:referential #:targetable #: #:title #:subtitle #:rubric
+   #:referential #:targetable #:title #:subtitle #:rubric
    #:docinfo #:author #:authors #:organization #:address #:contact
    #:version #:revision #:status #:date #:copyright #:decoration
    #:header #:footer #:structural #:section #:topic #:sidebar

--- a/parsers/regexp.lisp
+++ b/parsers/regexp.lisp
@@ -12,7 +12,9 @@
 ;;;Fragments of patterns used by transitions.
 
 (define-parse-tree-synonym wsp
-    (:char-class #\space #\newline #\Return #\tab #\Page #\Vt #\rubout))
+    (:char-class #\space #\newline #\Return #\tab #\Page #\rubout
+                 #+sbcl #\Vt
+                 #+ccl #\PageUp))
 
 (define-parse-tree-synonym alpha
     (:char-class (:range #\a #\z) (:range #\A #\Z)))

--- a/utilities.lisp
+++ b/utilities.lisp
@@ -12,10 +12,10 @@
 
 (defvar *tab-size* 8 "The amount of space that a tab is equivalent to")
 
-(defparameter +wsp+ '(#\space #\tab #\return #\newline #\Vt #\Page)
-  "White space characters")
+(defparameter +wsp+ (mapcar #'code-char '(32 9 13 10 12 11))
+  "White space characters: Space, Tab, Return, Newline, Page, PageUp")
 
-(deftype wsp() '(member #\space #\tab #\return #\newline #\Vt #\Page))
+(deftype wsp () `(member ,@(mapcar #'code-char '(32 9 13 10 12 11))))
 
 (declaim (inline wsp-char-p line-blank-p))
 (defun wsp-char-p(c) (typep c 'wsp))

--- a/writers/latex.lisp
+++ b/writers/latex.lisp
@@ -1323,7 +1323,7 @@ not supported in Latex"))
 
 (defmethod stream-write-char((stream latex-output-stream) (c character))
   (case c
-    (#\“ (write-sequence "``" stream))
+    ((code-char 8220) (write-sequence "``" stream))
     (#\” (write-sequence "''" stream))
     (#\" (write-sequence
           (if (alphanumericp (last-char stream)) "''" "``")


### PR DESCRIPTION
The only remaining problem is with docutils.writer.latex::encode. I couldn't figure it out but I'll file an issue.
