### PR TITLE
latex: make write-latex use same semantics as write-html

### DIFF
--- a/writers/html.lisp
+++ b/writers/html.lisp
@@ -63,7 +63,7 @@
       (let ((writer (make-instance 'html-writer)))
         (visit-node writer document)
         (write-document writer document os))
-      (with-open-file(s os :direction :output :if-exists :supersede :if-does-not-exist :create)
+      (with-open-file (s os :direction :output :if-exists :supersede :if-does-not-exist :create)
         (docutils:write-html s document))))
 
 (defmethod write-part((writer html-writer) (part (eql 'fragment)) (os stream))

--- a/writers/latex.lisp
+++ b/writers/latex.lisp
@@ -266,9 +266,12 @@ Default fallback method is remove \"-\" and \"_\" chars from docutils_encoding."
   (:documentation "Docutils latex writer"))
 
 (defun docutils:write-latex(os document)
-  (let ((writer (make-instance 'latex-writer)))
-    (visit-node writer document)
-    (write-document writer document os)))
+  (if (streamp os)
+      (let ((writer (make-instance 'latex-writer)))
+	(visit-node writer document)
+	(write-document writer document os))
+      (with-open-file (s os :direction :output :if-exists :supersede :if-does-not-exist :create)
+        (docutils:write-latex s document))))
 
 (defmacro collect-parts(&body body)
   `(progn


### PR DESCRIPTION
this is a simple change to make the write-html and write-latex
functions have the same semantics when you pass them a string rather
than an output stream.