### PR TITLE
Don't continue after signaling

### DIFF
--- a/parsers/state-machine.lisp
+++ b/parsers/state-machine.lisp
@@ -112,8 +112,7 @@ INPUT-SOURCE: name or path of source of INPUT_LINES."
          (*current-line-number* (abs-line-number state-machine)))
     (handler-bind((insert-lines
                    #'(lambda(e)
-                       (insert-lines state-machine (error-text-block e))
-                       (continue e))))
+                       (insert-lines state-machine (error-text-block e)))))
       (flet((extend-results(result) (when result (push result results))))
         (extend-results (bof state))
         (catch 'state-machine-eof


### PR DESCRIPTION
Hey, thanks for writing this library it's great, I have hit a small bug that requires an upstream fix

When running via a `roswell` script, the environment has a CONTINUE restart case higher in the stack, that triggers a non-local exit.  Based on my experimentation, there is no need to continue, instead we just need to remove that.

I'm no expert as to why `(continue e)` works in some cases but not others, it seems that if there is no restart case, it returns control to the original place there the condition was signaled from, but i can't find the exact details about this behavior in the spec, and haven't reached out on the mailing lists yet.  I'm using SBCL

I have a sample program to describe the problem that can be run with roswell, or interactively to demonstrate the issue.

```
#!/bin/sh
#|-*- mode:lisp -*-|#
#|
exec ros -Q -- $0 "$@"
|#

(define-condition my-condition (condition)
  ())

(define-condition my-condition1 (condition)
  ())

(defun test-condition ()
  (handler-bind ((my-condition
                   #'(lambda(e)
                       (format t "  Before attempting continue~%")
                       (dolist (r (compute-restarts e))
                         (format t "    ~s ~a~%" r r))
                       (continue e)
                       (format t "  Failed to find continue~%")))
                 (my-condition1
                   #'(lambda(e)
                       (declare (ignorable e))
                       (format t "  No attempt at continue~%"))))
    (format t "1. Attempt a condition with a restart~%")
    (restart-case
        (signal 'my-condition)
      (continue
          nil))
    (format t "1. The program succesfully continues running~%")

    (format t "2. Attempt a condition without a continue~%")
    (signal 'my-condition1)
    (format t "2. The program succesfully continues running~%")

    (format t "3. Attempt a condition without a restart~%")
    (signal 'my-condition)
    (format t "3. The program succesfully continues running~%")))

(trace test-condition)

(defun main ()
  (test-condition))
```

When running with roswell i see this
```
$ ./test.ros 
  0: (TEST-CONDITION)
1. Attempt a condition with a restart
  Before attempting continue
    #<RESTART CONTINUE {7FC70A946CA3}> CONTINUE
    #<RESTART RETRY {7FC70A947023}> Retry EVAL of current toplevel form.
    #<RESTART CONTINUE {7FC70A9470D3}> Ignore error and continue loading file NIL.
    #<RESTART ABORT {7FC70A947283}> Abort loading file NIL.
    #<RESTART CONTINUE {7FC70A9479B3}> Ignore runtime option --eval "(ros:run '((:eval\"(ros:asdf)\")(:eval\"(ros:quicklisp)\")(:script \"./test.ros\")(:quit ())))".
    #<RESTART ABORT {7FC70A947A53}> Skip rest of --eval and --load options.
    #<RESTART ABORT {7FC70A947C53}> Skip to toplevel READ/EVAL/PRINT loop.
    #<RESTART EXIT {7FC70A947BD3}> Exit SBCL (calling #'EXIT, killing the process).
1. The program succesfully continues running
2. Attempt a condition without a continue
  No attempt at continue
2. The program succesfully continues running
3. Attempt a condition without a restart
  Before attempting continue
    #<RESTART RETRY {7FC70A947023}> Retry EVAL of current toplevel form.
    #<RESTART CONTINUE {7FC70A9470D3}> Ignore error and continue loading file NIL.
    #<RESTART ABORT {7FC70A947283}> Abort loading file NIL.
    #<RESTART CONTINUE {7FC70A9479B3}> Ignore runtime option --eval "(ros:run '((:eval\"(ros:asdf)\")(:eval\"(ros:quicklisp)\")(:script \"./test.ros\")(:quit ())))".
    #<RESTART ABORT {7FC70A947A53}> Skip rest of --eval and --load options.
    #<RESTART ABORT {7FC70A947C53}> Skip to toplevel READ/EVAL/PRINT loop.
    #<RESTART EXIT {7FC70A947BD3}> Exit SBCL (calling #'EXIT, killing the process).
  0: TEST-CONDITION exited non-locally
```

When running via slime i see this
```
CL-USER> (test-condition)
                      
1. Attempt a condition with a restart
  Before attempting continue
    #<RESTART CONTINUE {7F5A82BBE913}> CONTINUE
    #<RESTART SWANK::RETRY {7F5A82BBECA3}> Retry SLIME REPL evaluation request.
    #<RESTART ABORT {7F5A82BBF063}> Return to SLIME's top level.
    #<RESTART ABORT {7F5A82BBFAA3}> Exit debugger, returning to top level.
1. The program succesfully continues running
2. Attempt a condition without a continue
  No attempt at continue
2. The program succesfully continues running
3. Attempt a condition without a restart
  Before attempting continue
    #<RESTART SWANK::RETRY {7F5A82BBECA3}> Retry SLIME REPL evaluation request.
    #<RESTART ABORT {7F5A82BBF063}> Return to SLIME's top level.
    #<RESTART ABORT {7F5A82BBFAA3}> Exit debugger, returning to top level.
  Failed to find continue
3. The program succesfully continues running
NIL
```
